### PR TITLE
Refactoring and fixes

### DIFF
--- a/Configuration/CacheSettings.cs
+++ b/Configuration/CacheSettings.cs
@@ -1,7 +1,13 @@
+using System.IO;
+
 namespace SteamKeyActivator.Configuration
 {
     public sealed class CacheSettings
     {
         public string CacheDirectoryPath { get; set; }
+
+        public string CookiesFilePath => Path.Combine(CacheDirectoryPath, "cookies.txt");
+
+        public string LastSteamGuardCodeFilePath => Path.Combine(CacheDirectoryPath, "last-steamguard-code.txt");
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -51,6 +51,8 @@ namespace SteamKeyActivator
             catch (AuthenticationException) { }
             catch (AggregateException ex)
             {
+                logger.Fatal(Operation.Unknown, OperationStatus.Failure, ex);
+
                 foreach (Exception innerException in ex.InnerExceptions)
                 {
                     logger.Fatal(Operation.Unknown, OperationStatus.Failure, innerException);

--- a/Program.cs
+++ b/Program.cs
@@ -112,6 +112,7 @@ namespace SteamKeyActivator
                 .AddSingleton<IProductKeyManagerClient, ProductKeyManagerClient>()
                 .AddSingleton<IWebDriver>(s => webDriver)
                 .AddSingleton<IWebProcessor, WebProcessor>()
+                .AddSingleton<ISteamAuthenticator, SteamAuthenticator>()
                 .AddSingleton<IKeyHandler, KeyUpdater>()
                 .AddSingleton<IKeyActivator, KeyActivator>()
                 .BuildServiceProvider();

--- a/Program.cs
+++ b/Program.cs
@@ -112,6 +112,7 @@ namespace SteamKeyActivator
                 .AddSingleton<IProductKeyManagerClient, ProductKeyManagerClient>()
                 .AddSingleton<IWebDriver>(s => webDriver)
                 .AddSingleton<IWebProcessor, WebProcessor>()
+                .AddSingleton<ICookieManager, CookieManager>()
                 .AddSingleton<ISteamAuthenticator, SteamAuthenticator>()
                 .AddSingleton<IKeyHandler, KeyUpdater>()
                 .AddSingleton<IKeyActivator, KeyActivator>()

--- a/Service/CookieManager.cs
+++ b/Service/CookieManager.cs
@@ -38,7 +38,7 @@ namespace SteamKeyActivator.Service
         {
             logger.Info(MyOperation.CookieLoading, OperationStatus.Started);
 
-            string cookiesFilePath = Path.Combine(cacheSettings.CacheDirectoryPath, "cookies.txt");
+            string cookiesFilePath = Path.Combine(cacheSettings.CookiesFilePath);
 
             if (!File.Exists(cookiesFilePath))
             {
@@ -86,7 +86,7 @@ namespace SteamKeyActivator.Service
         {
             logger.Info(MyOperation.CookieSaving, OperationStatus.Started);
 
-            string cookiesFilePath = Path.Combine(cacheSettings.CacheDirectoryPath, "cookies.txt"); 
+            string cookiesFilePath = Path.Combine(cacheSettings.CookiesFilePath); 
             string cookiesFileContent = string.Empty;       
             ReadOnlyCollection<Cookie> cookies = webDriver.Manage().Cookies.AllCookies;
 

--- a/Service/CookieManager.cs
+++ b/Service/CookieManager.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+
+using NuciLog.Core;
+using NuciWeb;
+
+using OpenQA.Selenium;
+
+using SteamKeyActivator.Configuration;
+using SteamKeyActivator.Logging;
+
+namespace SteamKeyActivator.Service
+{
+    public sealed class CookieManager : ICookieManager
+    {
+        static string HomePageUrl => "https://store.steampowered.com";
+
+        readonly IWebProcessor webProcessor;
+        readonly IWebDriver webDriver;
+        readonly CacheSettings cacheSettings;
+        readonly ILogger logger;
+
+        public CookieManager(
+            IWebProcessor webProcessor,
+            IWebDriver webDriver,
+            CacheSettings cacheSettings,
+            ILogger logger)
+        {
+            this.webProcessor = webProcessor;
+            this.webDriver = webDriver;
+            this.cacheSettings = cacheSettings;
+            this.logger = logger;
+        }
+
+        public void LoadCookies()
+        {
+            logger.Info(MyOperation.CookieLoading, OperationStatus.Started);
+
+            string cookiesFilePath = Path.Combine(cacheSettings.CacheDirectoryPath, "cookies.txt");
+
+            if (!File.Exists(cookiesFilePath))
+            {
+                return;
+            }
+
+            By logoSelector = By.Id("logo_holder");
+
+            webProcessor.GoToUrl(HomePageUrl);
+            webProcessor.WaitForElementToBeVisible(logoSelector);
+
+            IEnumerable<string> cookiesFileLines = File.ReadAllLines(cookiesFilePath);
+
+            webDriver.Manage().Cookies.DeleteAllCookies();
+
+            foreach (string cookieLine in cookiesFileLines)
+            {
+                string[] cookieLineFields = cookieLine.Split('Î');
+                DateTime? expiry = null;
+
+                if (!string.IsNullOrWhiteSpace(cookieLineFields[4]))
+                {
+                    expiry = DateTime.Parse(cookieLineFields[4]);
+                }
+
+                Cookie cookie = new Cookie(
+                    cookieLineFields[0],
+                    cookieLineFields[1],
+                    cookieLineFields[2],
+                    cookieLineFields[3],
+                    expiry);
+
+                webDriver.Manage().Cookies.AddCookie(cookie);
+            }
+
+            logger.Debug(MyOperation.CookieLoading, OperationStatus.Success);
+        }
+
+        public void SaveCookies()
+        {
+            logger.Info(MyOperation.CookieSaving, OperationStatus.Started);
+
+            string cookiesFilePath = Path.Combine(cacheSettings.CacheDirectoryPath, "cookies.txt"); 
+            string cookiesFileContent = string.Empty;       
+            ReadOnlyCollection<Cookie> cookies = webDriver.Manage().Cookies.AllCookies;
+
+            foreach (Cookie cookie in cookies)
+            {
+                cookiesFileContent +=
+                    cookie.Name + "Î" +
+                    cookie.Value + "Î" +
+                    cookie.Domain + "Î" +
+                    cookie.Path + "Î" +
+                    cookie.Expiry.ToString() +
+                    Environment.NewLine;
+            }
+
+            File.WriteAllText(cookiesFilePath, cookiesFileContent);
+
+            logger.Debug(MyOperation.CookieSaving, OperationStatus.Success);
+        }
+    }
+}

--- a/Service/CookieManager.cs
+++ b/Service/CookieManager.cs
@@ -15,7 +15,7 @@ namespace SteamKeyActivator.Service
 {
     public sealed class CookieManager : ICookieManager
     {
-        static string HomePageUrl => "https://store.steampowered.com";
+        const string HomePageUrl = "https://store.steampowered.com";
 
         readonly IWebProcessor webProcessor;
         readonly IWebDriver webDriver;

--- a/Service/CookieManager.cs
+++ b/Service/CookieManager.cs
@@ -90,6 +90,16 @@ namespace SteamKeyActivator.Service
             string cookiesFileContent = string.Empty;       
             ReadOnlyCollection<Cookie> cookies = webDriver.Manage().Cookies.AllCookies;
 
+            if (cookies.Count == 0)
+            {
+                logger.Warn(
+                    MyOperation.CookieSaving,
+                    OperationStatus.Failure,
+                    "There are no cookies to save");
+                
+                return;
+            }
+
             foreach (Cookie cookie in cookies)
             {
                 cookiesFileContent +=

--- a/Service/CookieManager.cs
+++ b/Service/CookieManager.cs
@@ -42,6 +42,11 @@ namespace SteamKeyActivator.Service
 
             if (!File.Exists(cookiesFilePath))
             {
+                logger.Warn(
+                    MyOperation.CookieLoading,
+                    OperationStatus.Failure,
+                    "The cookies file is missing");
+                
                 return;
             }
 

--- a/Service/ICookieManager.cs
+++ b/Service/ICookieManager.cs
@@ -1,0 +1,9 @@
+namespace SteamKeyActivator.Service
+{
+    public interface ICookieManager
+    {
+        void LoadCookies();
+
+        void SaveCookies();
+    }
+}

--- a/Service/ISteamAuthenticator.cs
+++ b/Service/ISteamAuthenticator.cs
@@ -1,0 +1,7 @@
+namespace SteamKeyActivator
+{
+    public interface ISteamAuthenticator
+    {
+        void LogIn();
+    }
+}

--- a/Service/SteamAuthenticator.cs
+++ b/Service/SteamAuthenticator.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Security.Authentication;
+
+using NuciLog.Core;
+using NuciWeb;
+
+using OpenQA.Selenium;
+
+using SteamKeyActivator.Configuration;
+using SteamKeyActivator.Logging;
+
+namespace SteamKeyActivator.Service
+{
+    public sealed class SteamAuthenticator : ISteamAuthenticator
+    {
+        static string HomePageUrl => "https://store.steampowered.com";
+        public string LoginUrl => $"{HomePageUrl}/login/?redir=&redir_ssl=1";
+
+        readonly IWebProcessor webProcessor;
+        readonly IWebDriver webDriver;
+        readonly BotSettings botSettings;
+        readonly CacheSettings cacheSettings;
+        readonly ILogger logger;
+
+        public SteamAuthenticator(
+            IWebProcessor webProcessor,
+            IWebDriver webDriver,
+            BotSettings botSettings,
+            CacheSettings cacheSettings,
+            ILogger logger)
+        {
+            this.webProcessor = webProcessor;
+            this.webDriver = webDriver;
+            this.botSettings = botSettings;
+            this.cacheSettings = cacheSettings;
+            this.logger = logger;
+        }
+
+        public void LogIn()
+        {
+            logger.Info(
+                MyOperation.SteamLogIn,
+                OperationStatus.Started,
+                new LogInfo(MyLogInfoKey.Username, botSettings.SteamUsername));
+
+            webProcessor.GoToUrl(LoginUrl);
+
+            By avatarSelector = By.XPath("//a[contains(@class,'user_avatar')]");
+
+            if (webProcessor.IsElementVisible(avatarSelector))
+            {
+                logger.Info(
+                    MyOperation.SteamLogIn,
+                    OperationStatus.Success,
+                    "Already logged in",
+                    new LogInfo(MyLogInfoKey.Username, botSettings.SteamUsername));
+                
+                return;
+            }
+
+            PerformLogIn();
+            ValidateLogInResult();
+
+            logger.Debug(
+                MyOperation.SteamLogIn,
+                OperationStatus.Success,
+                new LogInfo(MyLogInfoKey.Username, botSettings.SteamUsername));
+        }
+
+        void PerformLogIn()
+        {
+            By usernameInputSelector = By.Id("input_username");
+            By passwordInputSelector = By.Id("input_password");
+            By captchaInputSelector = By.Id("input_captcha");
+            By rememberLoginChecboxSelector = By.Id("remember_login");
+            By logInButtonSelector = By.XPath(@"//*[@id='login_btn_signin']/button");
+            
+            if (webProcessor.IsElementVisible(captchaInputSelector))
+            {
+                ThrowLogInException("Captcha input required");
+            }
+
+            webProcessor.SetText(usernameInputSelector, botSettings.SteamUsername);
+            webProcessor.SetText(passwordInputSelector, botSettings.SteamPassword);
+
+            if (webProcessor.IsElementVisible(rememberLoginChecboxSelector))
+            {
+                webProcessor.UpdateCheckbox(rememberLoginChecboxSelector, true);
+            }
+            
+            webProcessor.Click(logInButtonSelector);
+        }
+
+        void InputSteamGuardCodeIfRequired()
+        {
+            By avatarSelector = By.XPath("//a[contains(@class,'user_avatar')]");
+            By steamGuardCodeInputSelector = By.Id("twofactorcode_entry");
+            By steamGuardSubmitButtonSelector = By.XPath("//*[@id='login_twofactorauth_buttonset_entercode']/div[1]");
+
+            webProcessor.WaitForAnyElementToBeVisible(steamGuardCodeInputSelector, avatarSelector);
+
+            if (webProcessor.IsElementVisible(steamGuardCodeInputSelector))
+            {
+                webProcessor.SetText(steamGuardCodeInputSelector, botSettings.SteamGuardCode);
+                webProcessor.Click(steamGuardSubmitButtonSelector);
+            }
+        }
+
+        void ValidateLogInResult()
+        {
+            By avatarSelector = By.XPath("//a[contains(@class,'user_avatar')]");
+            By steamGuardIncorrectMessageSelector = By.Id("login_twofactorauth_message_incorrectcode");
+
+            webProcessor.WaitForAnyElementToBeVisible(avatarSelector, steamGuardIncorrectMessageSelector);
+
+            if (webProcessor.IsElementVisible(steamGuardIncorrectMessageSelector))
+            {
+                ThrowLogInException("The provided SteamGuard code is not valid");
+            }
+            else if (!webProcessor.IsElementVisible(avatarSelector))
+            {
+                ThrowLogInException("Authentication failure");
+            }
+        }
+
+        void ThrowLogInException(string message)
+        {
+            Exception ex = new AuthenticationException(message);
+
+            logger.Error(
+                MyOperation.SteamLogIn,
+                OperationStatus.Failure,
+                ex,
+                new LogInfo(MyLogInfoKey.Username, botSettings.SteamUsername));
+
+            throw ex;
+        }
+    }
+}

--- a/Service/SteamAuthenticator.cs
+++ b/Service/SteamAuthenticator.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.IO;
 using System.Security.Authentication;
 
 using NuciLog.Core;
@@ -16,26 +13,19 @@ namespace SteamKeyActivator.Service
 {
     public sealed class SteamAuthenticator : ISteamAuthenticator
     {
-        static string HomePageUrl => "https://store.steampowered.com";
-        public string LoginUrl => $"{HomePageUrl}/login/?redir=&redir_ssl=1";
+        const string LoginUrl = "https://store.steampowered.com/login/?redir=&redir_ssl=1";
 
         readonly IWebProcessor webProcessor;
-        readonly IWebDriver webDriver;
         readonly BotSettings botSettings;
-        readonly CacheSettings cacheSettings;
         readonly ILogger logger;
 
         public SteamAuthenticator(
             IWebProcessor webProcessor,
-            IWebDriver webDriver,
             BotSettings botSettings,
-            CacheSettings cacheSettings,
             ILogger logger)
         {
             this.webProcessor = webProcessor;
-            this.webDriver = webDriver;
             this.botSettings = botSettings;
-            this.cacheSettings = cacheSettings;
             this.logger = logger;
         }
 

--- a/Service/SteamAuthenticator.cs
+++ b/Service/SteamAuthenticator.cs
@@ -82,6 +82,8 @@ namespace SteamKeyActivator.Service
             }
             
             webProcessor.Click(logInButtonSelector);
+            
+            InputSteamGuardCodeIfRequired();
         }
 
         void InputSteamGuardCodeIfRequired()


### PR DESCRIPTION
 - Extracted the Steam authentication logic into its own component
 - Extracted the cookie management logic into its own component
 - Improved log in success/failure detection
 - Optimised and more robust authentication mechanism
 - Prevent logging in if the SteamGuard code had already been used previously (1)
 - Better logging when the log in fails
 - Better logging when managing the cookies

(1) This is done in order to prevent repeated authentication failures in case the cookies are not longer valid. The main reason is to prevent Steam from temporarily marking the activity on the current network as suspicious and requiring a captcha input to log in.