### PR TITLE
Conventional cookie file + fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: csharp
+mono: none
+dotnet: 2.2
+dist: xenial
+
+install:
+  - dotnet restore
+
+script:
+  - dotnet build

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+[![Build Status](https://travis-ci.com/hmlendea/steam-key-activator.svg?branch=master)](https://travis-ci.com/hmlendea/steam-key-activator)
+
 # steam-key-activator

--- a/Service/SteamAuthenticator.cs
+++ b/Service/SteamAuthenticator.cs
@@ -46,6 +46,8 @@ namespace SteamKeyActivator.Service
 
             if (webProcessor.IsElementVisible(avatarSelector))
             {
+                ValidateCurrentSession();
+
                 logger.Info(
                     MyOperation.SteamLogIn,
                     OperationStatus.Success,
@@ -109,6 +111,18 @@ namespace SteamKeyActivator.Service
             webProcessor.Click(steamGuardSubmitButtonSelector);
 
             SaveLastUsedSgCode();
+        }
+
+        void ValidateCurrentSession()
+        {
+            By accountPulldownSelector = By.Id("account_pulldown");
+
+            string currentUsername = webProcessor.GetText(accountPulldownSelector).Trim();
+
+            if (!botSettings.SteamUsername.Equals(currentUsername, StringComparison.InvariantCultureIgnoreCase))
+            {
+                ThrowLogInException("Already logged in as a different user");
+            }
         }
 
         void ValidateCredentials()

--- a/Service/SteamAuthenticator.cs
+++ b/Service/SteamAuthenticator.cs
@@ -145,14 +145,17 @@ namespace SteamKeyActivator.Service
                 ThrowLogInException("SteamGuard code not set");
             }
 
-            string lastUsedCode = File
-                .ReadAllText(cacheSettings.LastSteamGuardCodeFilePath)
-                .ToUpperInvariant()
-                .Trim();
-
-            if (lastUsedCode.Equals(botSettings.SteamGuardCode, StringComparison.InvariantCultureIgnoreCase))
+            if (File.Exists(cacheSettings.LastSteamGuardCodeFilePath))
             {
-                ThrowLogInException("The configured SteamGuard code is outdated");
+                string lastUsedCode = File
+                    .ReadAllText(cacheSettings.LastSteamGuardCodeFilePath)
+                    .ToUpperInvariant()
+                    .Trim();
+
+                if (lastUsedCode.Equals(botSettings.SteamGuardCode, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    ThrowLogInException("The configured SteamGuard code is outdated");
+                }
             }
         }
 

--- a/Service/SteamAuthenticator.cs
+++ b/Service/SteamAuthenticator.cs
@@ -127,12 +127,14 @@ namespace SteamKeyActivator.Service
 
         void ValidateCredentials()
         {
-            if (string.IsNullOrWhiteSpace(botSettings.SteamUsername))
+            if (string.IsNullOrWhiteSpace(botSettings.SteamUsername) ||
+                botSettings.SteamUsername == "[[STEAM_USERNAME]]")
             {
                 ThrowLogInException("Account username not set");
             }
 
-            if (string.IsNullOrWhiteSpace(botSettings.SteamPassword))
+            if (string.IsNullOrWhiteSpace(botSettings.SteamPassword) ||
+                botSettings.SteamPassword == "[[STEAM_PASSWORD]]")
             {
                 ThrowLogInException("Account password not set");
             }
@@ -140,7 +142,8 @@ namespace SteamKeyActivator.Service
 
         void ValidateSteamGuardCode()
         {
-            if (string.IsNullOrWhiteSpace(botSettings.SteamGuardCode))
+            if (string.IsNullOrWhiteSpace(botSettings.SteamGuardCode) ||
+                botSettings.SteamGuardCode == "[[STEAMGUARD_CODE]]")
             {
                 ThrowLogInException("SteamGuard code not set");
             }

--- a/Service/SteamAuthenticator.cs
+++ b/Service/SteamAuthenticator.cs
@@ -111,8 +111,26 @@ namespace SteamKeyActivator.Service
             SaveLastUsedSgCode();
         }
 
+        void ValidateCredentials()
+        {
+            if (string.IsNullOrWhiteSpace(botSettings.SteamUsername))
+            {
+                ThrowLogInException("Account username not set");
+            }
+
+            if (string.IsNullOrWhiteSpace(botSettings.SteamPassword))
+            {
+                ThrowLogInException("Account password not set");
+            }
+        }
+
         void ValidateSteamGuardCode()
         {
+            if (string.IsNullOrWhiteSpace(botSettings.SteamGuardCode))
+            {
+                ThrowLogInException("SteamGuard code not set");
+            }
+
             string lastUsedCode = File
                 .ReadAllText(cacheSettings.LastSteamGuardCodeFilePath)
                 .ToUpperInvariant()

--- a/SteamKeyActivator.csproj
+++ b/SteamKeyActivator.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="NuciExtensions" Version="1.4.1.1" />
     <PackageReference Include="NuciLog" Version="1.0.0" />
     <PackageReference Include="NuciLog.Core" Version="2.2.4" />
     <PackageReference Include="NuciSecurity.HMAC" Version="1.0.0" />


### PR DESCRIPTION
 - Changed to a conventional cookie file format
 - Added more authentication validations (1)
 - Validates that the currently logged in user is the configured one
 - Fixed exception when the cache file for the last used SteamGuard code is missing
 - Integrated with Travis CI

(1): Authentication will no longer be attempted in case that the username, password or SteamGuard code (if needed) is missing.
This, together with the new cookie file format, means that the user can opt to never set the password for his account, and instead only rely on setting up the cookie file.